### PR TITLE
Fix image spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,19 @@ Using our OS is really simple, on boot, you'll be greeted with a shell.
 - `mandelbrot` : show mandelbrot background
 - `ctheme` : change the theme with the following
   - legacy : 
+  
   ![image legacy](./screen/legacy.png)
+  
   - dark : 
+  
   ![image dark](./screen/dark.png)
+  
   - light : 
+  
   ![image light](./screen/light.png)
+  
   - witchcraft : 
+  
   ![image witchcraft](./screen/witchcraft.png)
 
 ## Using code


### PR DESCRIPTION
Github has a bug with markdown files (it doesn't pad images) and adding spaces in the file fixes it.

Before:

![Screenshot 2021-03-08 at 10 14 33 AM](https://user-images.githubusercontent.com/62703475/110340800-a6fa4000-7ff7-11eb-958c-9de25c955d3d.png)

After:

![Screenshot 2021-03-08 at 10 15 51 AM](https://user-images.githubusercontent.com/62703475/110340869-bbd6d380-7ff7-11eb-82b6-163af4c8a375.png)

