### PR TITLE
Fixes/Optimizations for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CFLAGS := \
 	-mcmodel=kernel \
 	-ffreestanding \
 	-fno-pie \
-	-O3 \
+	-O2 \
 	-s \
 	-Isrc/include \
 	-Wall \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KVM = 0
 
-LD = ld
-CC = gcc
+LD = cross/bin/x86_64-elf-ld
+CC = cross/bin/x86_64-elf-gcc
 AS = nasm
 
 ifeq ($(KVM), 1)

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ LDFLAGS := \
 	-static \
 	-no-pie \
 	-Tresources/linker.ld \
+	-Lcross/lib/gcc/x86_64-elf/9.2.0/\
 	-lgcc \
 	-nostdlib
 


### PR DESCRIPTION
Added the following flags for GCC: ```-O3 -fno-pie -s```
Added the following flags for LD: ```-lgcc```
Removed possibly obsolete code