### PR TITLE
Fix multiple definition error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ CFLAGS := \
 	-lm \
 	-std=gnu99 \
 	-Isrc/acpi/lai/include \
+	-fcommon \
 	-Isrc/include
 
 LDFLAGS := \


### PR DESCRIPTION
For some reason, GCC does not enable -fcommon by default, causing a linker error.

Edit 1: [It's a GCC known bug](https://bugs.gentoo.org/705764)