### PR TITLE
Change "Hello, world!" to "Welcome to Mandelbrot OS!"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -65,7 +65,7 @@ void kernel_main(struct stivale2_struct *bootloader_info) {
 
   scheduler_init(smp_info);
 
-  printf("Hello, world!\r\n");
+  printf("Welcome to Mandelbrot OS!\r\n");
 
   while (1)
     ;


### PR DESCRIPTION
Because hello world is too generic.