### PR TITLE
Ubuntu docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ AS = nasm
 
 # QEMU = qemu-system-$(ARCH) -hdd $(HDD) -smp 1 -M q35 -soundhw pcspk -serial stdio
 QEMU = qemu-system-$(ARCH) -hdd $(HDD) -smp 2 -M q35 -soundhw pcspk -serial stdio
+QEMU_DOCKER = $(QEMU) -curses
 
 HDD = mandelbrotos.hdd
 KERNEL = $(BUILD_DIRECTORY)/mandelbrotos.elf
@@ -82,29 +83,32 @@ clean:
 qemu: $(HDD)
 	@ $(QEMU)
 
+qemu_docker: $(HDD)
+	@ $(QEMU_DOCKER)
+
 toolchain:
 	# Limine
 	@ echo "[BUILD LIMINE]"
-	@ mv thirdparty/limine/limine-install-linux-x86_64 resources/limine-install
-	@ mv thirdparty/limine/limine.sys resources
-	@ mv thirdparty/limine/BOOTX64.EFI resources
+	@ cp -R thirdparty/limine/limine-install-linux-x86_64 resources/limine-install
+	@ cp -R thirdparty/limine/limine.sys resources
+	@ cp -R thirdparty/limine/BOOTX64.EFI resources
 	 
 	# Echfs
 	@ echo "[BUILD ECHFS]"
 	@ cd thirdparty/echfs; make echfs-utils; make mkfs.echfs
-	@ mv thirdparty/echfs/echfs-utils resources
+	@ cp -R thirdparty/echfs/echfs-utils resources
 
 toolchain_nonnative:
 	# Limine
 	@ echo "[BUILD LIMINE]"
-	@ mv thirdparty/limine/limine-install-linux-x86_64 resources/limine-install
-	@ mv thirdparty/limine/limine.sys resources
-	@ mv thirdparty/limine/BOOTX64.EFI resources
+	@ cp -R thirdparty/limine/limine-install-linux-x86_64 resources/limine-install
+	@ cp -R thirdparty/limine/limine.sys resources
+	@ cp -R thirdparty/limine/BOOTX64.EFI resources
 	 
 	# Echfs
 	@ echo "[BUILD ECHFS]"
 	@ cd thirdparty/echfs; make echfs-utils; make mkfs.echfs
-	@ mv thirdparty/echfs/echfs-utils resources
+	@ cp -R thirdparty/echfs/echfs-utils resources
 	 
 	# Cross compiler
 	@ echo "[BUILD CROSS COMPILER]"
@@ -115,3 +119,6 @@ toolchain_nonnative:
 	@ sed -i 's/CC = gcc/CC = cross/bin/$(ARCH)-elf-gcc/g' Makefile
 	@ sed -i 's/LD = ld/LD = cross/bin/$(ARCH)-elf-ld/g' Makefile
 
+docker_build:
+	@ docker build -f buildenv/Dockerfile . -t mandelbrot
+	@ docker run -it mandelbrot make qemu_docker 

--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -1,0 +1,17 @@
+# Ubuntu docker build 
+
+FROM ubuntu:18.04
+WORKDIR /devenv
+RUN apt-get update
+RUN apt-get install -y build-essential \
+                       qemu \
+                       nasm \ 
+                       xorriso \
+                       wget \
+                       mtools \
+                       uuid-dev \
+                       parted \
+                       udev \
+                       vim
+COPY ./ ./
+RUN make toolchain


### PR DESCRIPTION
- Added Dockerfile and Make recipes for `docker_build`. On OS X, this was the easiest way to get the OS up and running
- `mv`s in `make toolchain` where replaced with `cp -R`s  so that in the even that `make toolchain` fails the first time, it won't trigger `file or directory not found` the next time it is run
- Docker build is run with `make docker_build`