### PR TITLE
A lot of isalpha(3) functions

### DIFF
--- a/src/libc/src/ctype.c
+++ b/src/libc/src/ctype.c
@@ -1,6 +1,49 @@
 #include <ctype.h>
 #include <sys/mandelbrot.h>
 
+int isalnum(int c) {
+  return isdigit(c) || isalpha(c);
+}
+
+int isalpha(int c) {
+  return isupper(c) || islower(c);
+}
+
+int isblank(int c) {
+  return c == ' ' || c == '\t';
+}
+
+int iscntrl(int c) {
+  return (c >= 0 && c < ' ') || c == 0x7f /* DEL */;
+}
+
+int isdigit(int c) {
+  return c >= '0' && c <= '9';
+}
+
+int isspace(int c) {
+  return c == ' '
+    || c == '\f'
+    || c == '\n'
+    || c == '\r'
+    || c == '\t'
+    || c == '\v';
+}
+
+int islower(int c) {
+  return c >= 'a' && c <= 'z';
+}
+
+int isupper(int c) {
+  return c >= 'A' && c <= 'Z';
+}
+
+int isxdigit(int c) {
+  return isdigit(c)
+    || (c >= 'a' && c <= 'f')
+    || (c >= 'A' && c <= 'F');
+}
+
 int tolower(int c) {
   if (c >= 'A' && c <= 'Z')
     return c + 32;


### PR DESCRIPTION
Simple additions, wrote these out of the Linux Programmer's Manual's isalpha(3) page.

I didn't add isascii because it wasn't in C89 or C99 and was obsoleted in POSIX.1-2008.

All of these functions could be macros but I don't know if y'all would prefer that.