### PR TITLE
Simplify strlen(3)

### DIFF
--- a/src/libc/src/string.c
+++ b/src/libc/src/string.c
@@ -10,12 +10,10 @@ char *strchr(char *str, int c) {
 }
 
 size_t strlen(char *s) {
-  size_t count = 0;
-  while (*s != '\0') {
-    count++;
-    s++;
-  }
-  return count;
+  int i;
+  for (i = 0; s[i] != '\0'; ++i)
+    ;
+  return i;
 }
 
 void memcpy(void *dest, void *src, size_t n) {


### PR DESCRIPTION
This implementation of strlen(3) scrubs iteratively through memory so I figure putting that in a for statement is clearer to both humans and the compiler.

No need to increment `s` when you already have the index you need to check in memory (or probably a register). And you have to have that index in memory because that's the return value.

As far as I know this is the idiomatic solution; [I've used this](https://git.sr.ht/~trinity/src/tree/main/item/src/echo.c#L12) when I haven't wanted to include string.h.